### PR TITLE
Handle multiple binfiles, overhaul parameter handling, split WAV files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -63,3 +63,12 @@
 	Clarify manual page for input/output file types
 	Improvement from Reuben Thomas, debian bug: #503151
 
+1.2.3 - Jun 30 2022 - twojstaryzdomu
+
+	Added support for track # and multiple bin FILEs in cue sheet.
+	The output files are now named after the FILE with the appropriate
+	output extension added, without a track # inserted in between the
+	basename and the extension. The -t option includes the track # in
+	the output filenames as done by default in earlier releases.
+
+	Sealed various memory leaks. Refactored exit statements.

--- a/ChangeLog
+++ b/ChangeLog
@@ -72,3 +72,5 @@
 	the output filenames as done by default in earlier releases.
 
 	Sealed various memory leaks. Refactored exit statements.
+
+	Abort further processing if output file already exists.

--- a/ChangeLog
+++ b/ChangeLog
@@ -74,3 +74,8 @@
 	Sealed various memory leaks. Refactored exit statements.
 
 	Abort further processing if output file already exists.
+
+	Added support for ## as track # replacement token in the basename
+	parameter.
+
+	Added support for splitting WAV files into individual tracks.

--- a/README
+++ b/README
@@ -62,6 +62,9 @@
   	binchunker converts a CD image in a ".bin / .cue" format
   	(sometimes ".raw / .cue") to a set of .iso and .cdr tracks.
   	
+  	It also allows to split uncompressed PCM audio files in the
+  	WAV format into individual tracks.
+  	
   	The bin/cue format is used by some non-Unix cd-writing
   	software, but is not supported on most other cd-writing
   	programs.
@@ -118,9 +121,10 @@
   How to use this stuff:
   	
   	bchunk [-t] [-v] [-p (PSX)] [-r (raw)] [-w (wav)] [-s (swabaudio)]
-  	  <image.bin | track # | '*'> <image.cue> [ <basename> ]
+         <image.bin | image.wav | track # | '*'> <image.cue> [ <basename> ]
   	
-  	image.bin is a source raw cd image file listed in the
+  	image.bin is a source raw cd image file and image.wav is an
+  	uncompressed PCM audio file, either listed in the
   	cue sheet file as a FILE. track # identifies the track listed
   	in the cue sheet as a TRACK. The wildcard '*' (quoted)
   	selects all tracks for conversion. image.cue is the cue sheet
@@ -128,7 +132,8 @@
   	basename is used for the leading part of the output filenames.
   	By default, the output files are now named after the basename
   	of the source image file or the track #, ending with the
-  	appropriate format extension.
+  	appropriate format extension. basename may contain the track
+  	token ## which will be replaced by the track number.
 	
 	The -t flag adds the track # in the output filename between
 	the basename & the extension, as in versions prior to 1.2.3.

--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 
-	binchunker for Unix, version 1.2.2
+	binchunker for Unix, version 1.2.3
 	Copyright (C) 1998-2004  Heikki Hannikainen <hessu@hes.iki.fi>
 	
 	Enhancements provided by:
@@ -9,6 +9,7 @@
 		Piotr Kaczuba <pepe@attika.ath.cx>, 2009
 		Reuben Thomas <rrt@femur.dyndns.org>, 2008
 		Yegor Timoshenko <yegortimoshenko@gmail.com>, 2017
+		twojstaryzdomu <@github.com>, 2022
 
 		
 	http://he.fi/bchunk/
@@ -85,8 +86,8 @@
   	
   How to install this stuff:
   	
-  	$ gzip -d -c bchunk-1.2.2.tar.gz | tar xvf -
-  	$ cd bchunk-1.2.2
+  	$ gzip -d -c bchunk-1.2.3.tar.gz | tar xvf -
+  	$ cd bchunk-1.2.3
   	$ make
   	# make install
   	
@@ -116,13 +117,21 @@
   	
   How to use this stuff:
   	
-  	bchunk [-v] [-p (PSX)] [-r (raw)] [-w (wav)] [-s (swabaudio)]
-  	  <image.bin> <image.cue> <basename>
+  	bchunk [-t] [-v] [-p (PSX)] [-r (raw)] [-w (wav)] [-s (swabaudio)]
+  	  <image.bin | track # | '*'> <image.cue> [ <basename> ]
   	
-  	image.bin is the raw cd image file. image.cue is the
-  	track index file containing track types and offsets.
-  	basename is used for the beginning part of the created
-  	track files.
+  	image.bin is a source raw cd image file listed in the
+  	cue sheet file as a FILE. track # identifies the track listed
+  	in the cue sheet as a TRACK. The wildcard '*' (quoted)
+  	selects all tracks for conversion. image.cue is the cue sheet
+  	file containing filenames, track types and offsets. The optional
+  	basename is used for the leading part of the output filenames.
+  	By default, the output files are now named after the basename
+  	of the source image file or the track #, ending with the
+  	appropriate format extension.
+	
+	The -t flag adds the track # in the output filename between
+	the basename & the extension, as in versions prior to 1.2.3.
 	
 	The -v flag makes binchunker print some more unnecessary
 	messages, which should not be of interest for anyone.
@@ -137,7 +146,7 @@
 	The -p and -r flags works only with MODE2/2352 input (if input
 	is in PSX mode pass -p flag or if it is in raw format pass
 	-r flag).
-
+	
 	The -w flag makes binchunker write audio tracks in WAV format.
 	
 	The -s flag makes binchunker swap byte order in the samples of

--- a/bchunk.1
+++ b/bchunk.1
@@ -1,9 +1,10 @@
 .TH BCHUNK 1 "v1.2.3 30 Jun 2022" "Heikki Hannikainen"
 .SH NAME
 bchunk \- CD image format conversion from bin/cue to iso/cdr
+and WAV file splitter
 .SH SYNOPSIS
 .B bchunk [-t] [-v] [-p] [-r] [-w] [-s]
-<image.bin | track # | '*'> <image.cue> [ <basename> ]
+<image.bin | image.wav | track # | '*'> <image.cue> [ <basename> ]
 .SH DESCRIPTION
 .LP
 .B bchunk 
@@ -14,13 +15,18 @@ The bin/cue format is used by some non-Unix cd-writing
 software, but is not supported on most other cd-writing
 programs.
 .LP
-image.bin is a raw cd image file listed in the cue sheet as a FILE.
+It also allows to split uncompressed PCM audio files in the
+WAV format into individual tracks.
+.LP
+image.bin is a raw cd image file and image.wav is an uncompressed
+PCM audio file, either listed in the cue sheet file as a FILE.
 track # is the track number listed in the cue sheet as a TRACK.
 track # may omit the leading 0s. The wildcard '*' (single quoted to
 prevent shell expansion) selects all tracks from a cue sheet for
 conversion. image.cue is the cue sheet file containing track types
 and offsets. basename is optionally used for the leading part of
-output filenames.
+output filenames. basename may contain the track token '##'
+which will be replaced by the track number.
 .LP
 The produced .iso track contains an ISO file system, which can be
 mounted through a loop device on Linux systems, or
@@ -72,6 +78,10 @@ raw format.
 .TP 5
 .B image.bin
 Raw CD image file, listed in the cue sheet as a FILE.
+.TP 5
+.B image.wav
+WAV file with uncompressed PCM audio, listed in the cue sheet
+as a FILE.
 .TP 5
 .B image.cue
 Cue sheet, TOC (Track index, Table Of Contents) file.

--- a/bchunk.1
+++ b/bchunk.1
@@ -1,8 +1,9 @@
-.TH BCHUNK 1 "v1.2.2 14 Nov 2017" "Heikki Hannikainen"
+.TH BCHUNK 1 "v1.2.3 30 Jun 2022" "Heikki Hannikainen"
 .SH NAME
 bchunk \- CD image format conversion from bin/cue to iso/cdr
 .SH SYNOPSIS
-.B bchunk [-v] [-p] [-r] [-w] [-s] <image.bin> <image.cue> <basename>
+.B bchunk [-t] [-v] [-p] [-r] [-w] [-s]
+<image.bin | track # | '*'> <image.cue> [ <basename> ]
 .SH DESCRIPTION
 .LP
 .B bchunk 
@@ -13,10 +14,13 @@ The bin/cue format is used by some non-Unix cd-writing
 software, but is not supported on most other cd-writing
 programs.
 .LP
-image.bin is the raw cd image file. image.cue is the
-track index file containing track types and offsets.
-basename is used for the beginning part of the created
-track files.
+image.bin is a raw cd image file listed in the cue sheet as a FILE.
+track # is the track number listed in the cue sheet as a TRACK.
+track # may omit the leading 0s. The wildcard '*' (single quoted to
+prevent shell expansion) selects all tracks from a cue sheet for
+conversion. image.cue is the cue sheet file containing track types
+and offsets. basename is optionally used for the leading part of
+output filenames.
 .LP
 The produced .iso track contains an ISO file system, which can be
 mounted through a loop device on Linux systems, or
@@ -37,6 +41,12 @@ desired, respectively.
 The format itself does not contain this feature and in an ambiguous
 case it can only guess.
 .SH OPTIONS
+.TP 10
+.BI \-t
+Adds the track # in the output filename between the basename &
+the extension, as in
+.B bchunk
+releases prior to 1.2.3.
 .TP 10
 .BI \-v
 Makes binchunker print some more unnecessary messages, which should
@@ -61,10 +71,10 @@ raw format.
 .LP
 .TP 5
 .B image.bin
-Raw CD image file
+Raw CD image file, listed in the cue sheet as a FILE.
 .TP 5
 .B image.cue
-TOC (Track index, Table Of Contents) file
+Cue sheet, TOC (Track index, Table Of Contents) file.
 .TP 5
 .B *.iso
 Tracks in ISO9660 CD filesystem format. Can be either written on a
@@ -94,4 +104,6 @@ Colas Nahaboo <Colas@Nahaboo.com>
 Godmar Back <gback@cs.utah.edu>
 .br
 Matthew Green <mrg@eterna.com.au>
+.br
+twojstaryzdomu <@github.com>
 .br

--- a/bchunk.1
+++ b/bchunk.1
@@ -18,15 +18,16 @@ programs.
 It also allows to split uncompressed PCM audio files in the
 WAV format into individual tracks.
 .LP
-image.bin is a raw cd image file and image.wav is an uncompressed
-PCM audio file, either listed in the cue sheet file as a FILE.
-track # is the track number listed in the cue sheet as a TRACK.
-track # may omit the leading 0s. The wildcard '*' (single quoted to
-prevent shell expansion) selects all tracks from a cue sheet for
-conversion. image.cue is the cue sheet file containing track types
-and offsets. basename is optionally used for the leading part of
-output filenames. basename may contain the track token '##'
-which will be replaced by the track number.
+\fIimage.bin\fP is a raw cd image file and \fIimage.wav\fP is an
+uncompressed  PCM audio file, either listed in the cue sheet file
+as a FILE. \fItrack #\fP is the track number listed in the cue sheet
+as a TRACK. \fItrack #\fP may omit the leading 0s. The wildcard
+'\fI*\fP' (single quoted to prevent shell expansion) selects all
+tracks from a cue sheet for conversion. \fIimage.cue\fP is the cue
+sheet file containing track types and offsets. \fIbasename\fP is
+optionally used for the leading part of output filenames.
+\fIbasename\fP may contain the track token '##' which will be
+replaced by the track number.
 .LP
 The produced .iso track contains an ISO file system, which can be
 mounted through a loop device on Linux systems, or

--- a/bchunk.c
+++ b/bchunk.c
@@ -295,11 +295,14 @@ int writetrack(FILE *bf, struct track_t *track, char *bname)
 	
 	reallen = (track->stopsect - track->startsect + 1) * track->bsize;
 	if (verbose) {
-		printf("\n mmc sectors %ld->%ld (%ld)", track->startsect, track->stopsect, track->stopsect - track->startsect + 1);
-		printf("\n mmc bytes %ld->%ld (%ld)", track->start, track->stop, track->stop - track->start + 1);
-		printf("\n sector data at %d, %d bytes per sector", track->bstart, track->bsize);
-		printf("\n real data %ld bytes", (track->stopsect - track->startsect + 1) * track->bsize);
-		printf("\n");
+		printf(	"\n mmc sectors %ld->%ld (%ld)"
+			"\n mmc bytes %ld->%ld (%ld)"
+			"\n sector data at %d, %d bytes per sector"
+			"\n real data %ld bytes\n",
+			track->startsect, track->stopsect, track->stopsect - track->startsect + 1,
+			track->start, track->stop, track->stop - track->start + 1,
+			track->bstart, track->bsize,
+			reallen);
 	}
 
 	printf("                                          ");

--- a/bchunk.c
+++ b/bchunk.c
@@ -47,6 +47,9 @@
 		"\tGodmar Back <gback@cs.utah.edu>, Colas Nahaboo <Colas@Nahaboo.com>\n" \
 		"\tMatthew Green <mrg@eterna.com.au> & twojstaryzdomu <@github.com>.\n" \
 		"\tReleased under the GNU GPL, version 2 or later (at your option).\n\n"
+	
+#define HINT	"\nUse '-t' to include track # in output filename. " \
+		"Remaining tracks were not processed\n"
 
 #define CUELLEN 1024
 #define SECTLEN 2352
@@ -332,10 +335,15 @@ int writetrack(FILE *bf, struct track_t *track)
 	int16_t i;
 	float fl;
 	
-	printf("%2d: %s ", track->num, track->output);
+	if (!(f = fopen(track->output, "wbx"))) {
+		if (errno == EEXIST)
+			die_format(5,	"%2d: skipped: output file %s already exists, aborting\n%s",
+					track->num, track->output, HINT);
+		else
+			die_format(4, " Could not fopen track file: %s\n", strerror(errno));
+	}
 	
-	if (!(f = fopen(track->output, "wb")))
-		die_format(4, " Could not fopen track file: %s\n", strerror(errno));
+	printf("%2d: %s ", track->num, track->output);
 	
 	if (fseek(bf, track->start, SEEK_SET))
 		die_format(4, " Could not fseek to track location: %s\n", strerror(errno));
@@ -463,6 +471,9 @@ int set_output(struct track_t *track, char *binfile, char *basefile, int trackad
 		die(4, "set_output(): asprintf() failed, out of memory\n");
 	free(bname);
 	bname = NULL;
+	if (strcmp(track->output, track->file) == 0)
+		die_format(5,   "%2d: skipped: output file %s same as input file, aborting\n%s",
+				track->num, track->output, HINT);
 	return 1;
 }
 

--- a/bchunk.spec
+++ b/bchunk.spec
@@ -1,5 +1,5 @@
 %define name bchunk
-%define version 1.2.2
+%define version 1.2.3
 %define release 0
 
 Summary: A CD image format converter from .bin/.cue to .iso/.cdr/.wav.
@@ -43,6 +43,9 @@ rm -r $RPM_BUILD_ROOT
 %{_mandir}/man1/bchunk.1.gz
 
 %changelog
+* Tue Jun 30 2022 twojstaryzdomu
+- updated to 1.2.3
+
 * Tue Nov 14 2017 Hessu <hessu@hes.iki.fi>
 - updated to 1.2.2
 


### PR DESCRIPTION
This PR enables the following:
1. Handle image based on cuesheet FILE definitions. The first parameter is used to select the track or file to convert. Specifying a track will convert a specific track whilst specifying a file will convert all tracks for a given file. Filename has to match its cuesheet definition. Wildcard `*` (in single quotes) selects all tracks from all files listed.
2. Split input WAV files. It's now possible to split a single WAV file into individual WAV tracks or raw cdr files, convenient for processing CD Audio rips stored as a single WAV and a cue sheet.
3. Basefile parameter is now optional. If omitted, the output files are named after the file or track being processed, prepended with the format extension.
4. Replace `##` as track token in basename. I doubt this combination is used anywhere in filenames.
5. Error out if the output file already exists. Previously an existing output file would get overwritten. It also covers the case when two files of the same name would get output (when `-t` or the variant basename isn't specified .
6. No track # included in the output filename unless `-t` is specified.
7. Repeating error statements were refactored into functions.
8. Sealed memory leaks.
9. Version raised to 1.2.3, credits, manpage, README & Changelog updated.