### PR TITLE
Added support for CUE files that reference multiple BINs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -63,3 +63,14 @@
 	Clarify manual page for input/output file types
 	Improvement from Reuben Thomas, debian bug: #503151
 
+1.3.0 - Feb 01 2026 - Jakemkz
+
+	Added support for split bin files for example those produced by
+	redumper using the new -m flag
+
+	Added support for converting pre-gap audio tracks to wav.
+	
+	Added additional logic to ensure audio tracks are started at INDEX 01
+
+	Added debug mode to makefile with strict compiler flags and made
+	adjustments to compile without warnings

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # For systems with GCC (Linux, and others with GCC installed):
 CC = gcc
 LD = gcc
-CFLAGS = -Wall -Wstrict-prototypes -O2 -Wextra -pedantic -Werror
+CFLAGS = -Wall -Wstrict-prototypes -O2
 CFLAGS_PED = -Wall -Wstrict-prototypes -O2 -g -Wextra -pedantic -Werror -Wformat -Wconversion -Wstrict-aliasing -Wundef -Wshadow -Wsign-conversion -fstrict-overflow
 
 all: bchunk

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
+all: bchunk
+
 # For systems with GCC (Linux, and others with GCC installed):
 CC = gcc
 LD = gcc
 CFLAGS = -Wall -Wstrict-prototypes -O2
-CFLAGS_PED = -Wall -Wstrict-prototypes -O2 -g -Wextra -pedantic -Werror -Wformat -Wconversion -Wstrict-aliasing -Wundef -Wshadow -Wsign-conversion -fstrict-overflow
-
-all: bchunk
+CFLAGS_PED = -Wall -Wstrict-prototypes -O2 -g -Wextra -pedantic  -Wformat -Wconversion -Wstrict-aliasing -Wundef -Wshadow -Wsign-conversion -fstrict-overflow
 
 # For systems with a legacy CC:
 #CC = cc
@@ -13,6 +13,9 @@ all: bchunk
 
 # For BSD install: Which install to use and where to put the files
 INSTALL = install
+INSTALL_DIR = $(INSTALL) -d -m 0755
+INSTALL_DATA = $(INSTALL) -m 0644
+INSTALL_EXEC = $(INSTALL) -m 0755
 PREFIX  = /usr/local
 BIN_DIR = $(PREFIX)/bin
 MAN_DIR = $(PREFIX)/man
@@ -20,8 +23,8 @@ MAN_DIR = $(PREFIX)/man
 .c.o:
 	$(CC) $(CFLAGS) -c $<
 
-debug:	CFLAGS = $(CFLAGS_PED)
-debug:	bchunk
+debug: CFLAGS = $(CFLAGS_PED)
+debug: bchunk
 
 clean:
 	rm -f *.o *~ *.bak core
@@ -30,9 +33,11 @@ distclean: clean
 
 install: installbin installman
 installbin:
-	$(INSTALL) -m 755 -s -o root -g root bchunk		$(BIN_DIR)
+	$(INSTALL_DIR) $(DESTDIR)$(BIN_DIR)
+	$(INSTALL_EXEC) -s bchunk $(DESTDIR)$(BIN_DIR)
 installman:
-	$(INSTALL) -m 644 -o bin -g bin bchunk.1	 	$(MAN_DIR)/man1
+	$(INSTALL_DIR) $(DESTDIR)$(MAN_DIR)/man1
+	$(INSTALL_DATA) bchunk.1 $(DESTDIR)$(MAN_DIR)/man1
 
 BITS = bchunk.o
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
-all: bchunk
-
 # For systems with GCC (Linux, and others with GCC installed):
 CC = gcc
 LD = gcc
-CFLAGS = -Wall -Wstrict-prototypes -O2
+CFLAGS = -Wall -Wstrict-prototypes -O2 -Wextra -pedantic -Werror
+CFLAGS_PED = -Wall -Wstrict-prototypes -O2 -g -Wextra -pedantic -Werror -Wformat -Wconversion -Wstrict-aliasing -Wundef -Wshadow -Wsign-conversion -fstrict-overflow
+
+all: bchunk
 
 # For systems with a legacy CC:
 #CC = cc
@@ -12,15 +13,15 @@ CFLAGS = -Wall -Wstrict-prototypes -O2
 
 # For BSD install: Which install to use and where to put the files
 INSTALL = install
-INSTALL_DIR = $(INSTALL) -d -m 0755
-INSTALL_DATA = $(INSTALL) -m 0644
-INSTALL_EXEC = $(INSTALL) -m 0755
 PREFIX  = /usr/local
 BIN_DIR = $(PREFIX)/bin
 MAN_DIR = $(PREFIX)/man
 
 .c.o:
 	$(CC) $(CFLAGS) -c $<
+
+debug:	CFLAGS = $(CFLAGS_PED)
+debug:	bchunk
 
 clean:
 	rm -f *.o *~ *.bak core
@@ -29,16 +30,14 @@ distclean: clean
 
 install: installbin installman
 installbin:
-	$(INSTALL_DIR) $(DESTDIR)$(BIN_DIR)
-	$(INSTALL_EXEC) -s bchunk $(DESTDIR)$(BIN_DIR)
+	$(INSTALL) -m 755 -s -o root -g root bchunk		$(BIN_DIR)
 installman:
-	$(INSTALL_DIR) $(DESTDIR)$(MAN_DIR)/man1
-	$(INSTALL_DATA) bchunk.1 $(DESTDIR)$(MAN_DIR)/man1
+	$(INSTALL) -m 644 -o bin -g bin bchunk.1	 	$(MAN_DIR)/man1
 
 BITS = bchunk.o
 
 bchunk: $(BITS)
-	$(LD) -o bchunk $(BITS) $(LDFLAGS)
+	$(LD) $(LDFLAGS) -o bchunk $(BITS)
 
 bchunk.o:	bchunk.c
 

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ installman:
 BITS = bchunk.o
 
 bchunk: $(BITS)
-	$(LD) $(LDFLAGS) -o bchunk $(BITS)
+	$(LD) -o bchunk $(BITS) $(LDFLAGS) 
 
 bchunk.o:	bchunk.c
 

--- a/README
+++ b/README
@@ -52,7 +52,7 @@
 	Colas Nahaboo <Colas@Nahaboo.com> and Godmar Back <gback@cs.utah.edu>
 	added support for MODE2/2352 ISO data tracks in bchunk 1.1.0.
 	Matthew Green implemented the -r option for raw MODE2/2352
-	exctraction for bchunk 1.2.0.
+	extraction for bchunk 1.2.0.
   	
   	---
   

--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 
-	binchunker for Unix, version 1.2.2
+	binchunker for Unix, version 1.3.0
 	Copyright (C) 1998-2004  Heikki Hannikainen <hessu@hes.iki.fi>
 	
 	Enhancements provided by:

--- a/README
+++ b/README
@@ -52,7 +52,7 @@
 	Colas Nahaboo <Colas@Nahaboo.com> and Godmar Back <gback@cs.utah.edu>
 	added support for MODE2/2352 ISO data tracks in bchunk 1.1.0.
 	Matthew Green implemented the -r option for raw MODE2/2352
-	extraction for bchunk 1.2.0.
+	exctraction for bchunk 1.2.0.
   	
   	---
   
@@ -85,8 +85,8 @@
   	
   How to install this stuff:
   	
-  	$ gzip -d -c bchunk-1.2.2.tar.gz | tar xvf -
-  	$ cd bchunk-1.2.2
+  	$ gzip -d -c bchunk-1.3.0.tar.gz | tar xvf -
+  	$ cd bchunk-1.3.0
   	$ make
   	# make install
   	
@@ -144,5 +144,8 @@
 	the audio tracks. If the audio sounds like loud static noise,
 	try this.
 	
-
-
+	The -m flag make binchunker use file names provided in the .cue
+	file and merge them into a new combined binary <image.bin>. 
+	This is intended to correctly handle split .bin files like those
+	produced by redumper.
+	

--- a/README
+++ b/README
@@ -144,7 +144,7 @@
 	the audio tracks. If the audio sounds like loud static noise,
 	try this.
 	
-	The -m flag make binchunker use file names provided in the .cue
+	The -m flag makes binchunker use file names provided in the .cue
 	file and merge them into a new combined binary <image.bin>. 
 	This is intended to correctly handle split .bin files like those
 	produced by redumper.

--- a/bchunk.1
+++ b/bchunk.1
@@ -1,4 +1,4 @@
-.TH BCHUNK 1 "v1.2.2 14 Nov 2017" "Heikki Hannikainen"
+.TH BCHUNK 1 "v1.3.0 01 Feb 2026" "Heikki Hannikainen"
 .SH NAME
 bchunk \- CD image format conversion from bin/cue to iso/cdr
 .SH SYNOPSIS

--- a/bchunk.c
+++ b/bchunk.c
@@ -672,6 +672,7 @@ int main(int argc, char **argv)
 
 	if (merge) {
 		fclose(mergef);
+		fclose(mergecf);
 	} else {
 		fclose(binf);
 	}

--- a/bchunk.c
+++ b/bchunk.c
@@ -483,26 +483,18 @@ int main(int argc, char **argv)
 		return 2;
 	}
 
-	if (verbose)
+	if (verbose) {
+		printf("Reading the CUE file\n");
 		printf("Path to BIN/CUE files:%s\n",bindir);
-	
-	/* This unnecessarily ate the first line of the cue file
-	 * which is usually used for file definitions. removed this
-	 * to handle file descriptions correctly in -m (merge) mode
-	 */
-	/* We don't really care about the first line. */
-	/*if (!fgets(s, CUELLEN, cuef)) {
-		fprintf(stderr, "Could not read first line from %s: %s\n", cuefile, strerror(errno));
-		return 3;
 	}
-	*/
 
+	// loop over lines in CUE file
 	while (fgets(s, CUELLEN, cuef)) {
 		while ((p = strchr(s, '\r')) || (p = strchr(s, '\n')))
 			*p = '\0';
 			
 		if (!strstr(s, "FILE") && !strstr(s, "INDEX") && merge)
-			fprintf(mergecf, "%s\n",s); // copy track line as-is
+			fprintf(mergecf, "%s\n",s); // copy all lines as-is except FILE/INDEX
 
 		if ((p = strstr(s, "TRACK"))) {
 			printf("\nTrack ");
@@ -567,6 +559,9 @@ int main(int argc, char **argv)
 					prevtrack->stop = track->start - 1;
 				}
 			} else if ((strcmp(p,"00") == 0) && (track->num == 1) && (track->audio == 1)) {
+				// special handling for audio at INDEX 00 on TRACK 01
+				// split audio out into track->num 0 so that pre-gap
+				// audio is preserved, create a new track for INDEX 01
 				printf("detected pregap track at track one\n");
 				track->num = 0;
 				track->startsect = prevsectoroffset + time2frames(t);
@@ -591,9 +586,6 @@ int main(int argc, char **argv)
 				track->bsize = prevtrack->bsize;
 				track->bstart = prevtrack->bstart;
 				track->startsect = track->stopsect = -1;
-
-				// add commands to create an additional track here
-				// same configuration as this track
 
 			}
 		} else if ((p = strstr(s, "FILE"))) {


### PR DESCRIPTION
This pull request adds the following features to bchunk which may be useful to individuals seeking to archive CDs and handle a few corner cases in CD preservation. I have attempted to maintain backwards compatibility with existing bchunk usage while extending its capabilities

**1. Added support for handling CUE sheets with multiple BIN files**

This was added with the use of a new flag "-m" for merge. In this mode the file passed in the <image.cue> argument is used to identify files based on FILE line descriptors in the CUE file. The referenced .BIN files should be in the same directory as <image.cue>. The meaning of <image.bin> in this mode is changed from being an input file to being an output file that is the combination of all .BIN files. A .CUE file with the same basename as <image.bin> is also created with adjusted INDEX times to match the merged .BIN. 

If merge mode is used with only two arguments bchunk will only create the merged bin/cue files and take no further actions but it can also be used with other flags such as -w to create the merged bin and produce the normal output wav/iso files.

**2. Adjustment of INDEX handling logic and support for pre-gap audio**

The handling logic for identifying the separation point between tracks was adjusted to ensure that this occurs at INDEX 01 even for CUE files that may have multiple INDEX entries, this is intended to match the behavior of a CD player where data in INDEX 00 would be played as part of the previous TRACK.

Special handling was added for INDEX 00 on TRACK 01 that creates a separate "track 0" for pre-gap audio if it exists. 

**3. Minor datatype and makefile adjustments**

A few of the data types were changed from variable length to fixed length types. These changes aren't necessary but reduce some of the compiler warnings using the most pedantic settings.

Added the 'make debug' option to the makefile which uses the -g flag for debugging with gdb along with very pedantic warnings from the compiler


Other notes:
- These changes are intended to work well with split bin/cue files produced by redumper which may be useful for folks trying to archive compact discs.
- You should really only use merge mode on CUE files that you trust or have read since it uses the FILE references to open files on your computer and write the output to other files
- I'm not a software engineer, just a person trying to make the tools I use a bit better, so there may be mistakes in my code but I have tested it on some of my available media and it has worked well. I have also done binary comparisons of files produced from the merged bin/cue files (using the legacy codepath) and the merge option which resulted in identical files in several test cases.
- Also forgive me if I have made any faux pas in this pull request, its my first one.